### PR TITLE
Add configurable vhost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ YAML file for worker configuration.
 
 `RABBITMQ_PASS` - Password to connect with
 
+`RABBITMQ_VHOST` - Virtual host to use (default is "/")
+
 At the moment `guest:guest` are used to connect, just because I have gotten around to changing it.
 
 ### Startup Configuration

--- a/amqpdispatcher/dispatcher.py
+++ b/amqpdispatcher/dispatcher.py
@@ -74,6 +74,7 @@ def setup():
         hosts = [os.getenv('RABBITMQ_HOST', 'localhost')]
     user = os.getenv('RABBITMQ_USER', 'guest')
     password = os.getenv('RABBITMQ_PASS', 'guest')
+    vhost = os.getenv('RABBITMQ_VHOST', '/')
     rabbit_logger = logging.getLogger('amqp-dispatcher.haigha')
     conn = connect_to_hosts(
         RabbitConnection,
@@ -81,6 +82,7 @@ def setup():
         transport='gevent',
         user=user,
         password=password,
+        vhost=vhost,
         logger=rabbit_logger
     )
     if conn is None:


### PR DESCRIPTION
With RABBITMQ_VHOST, like the other RABBITMQ_HOST, USER, and PASS environment variables.
