### PR TITLE
Fix import path for RabbitConnection

### DIFF
--- a/amqpdispatcher/dispatcher.py
+++ b/amqpdispatcher/dispatcher.py
@@ -9,7 +9,7 @@ import socket
 import sys
 
 from haigha.connection import Connection as haigha_Connection
-from haigha.connections import RabbitConnection
+from haigha.connections.rabbit_connection import RabbitConnection
 from haigha.message import Message
 from yaml import safe_load as load
 import gevent


### PR DESCRIPTION
In haigha 0.7.1, there is a BC break where the RabbitConnection is no longer imported in haigha.connections.**init**.py

https://github.com/agoragames/haigha/commit/d2281ee7369a7231aaa7f9a19220f3af93e3fa49
