### PR TITLE
Fixes locked consumers

### DIFF
--- a/amqpdispatcher/dispatcher.py
+++ b/amqpdispatcher/dispatcher.py
@@ -154,6 +154,8 @@ class ConsumerPool(object):
 
             def put_back(successful_greenlet):
                 logger.debug('Successful run, putting consumer back')
+                if not amqp_proxy.has_responded_to_message:
+                    amqp_proxy.ack()
                 self._pool.put(consumer)
 
             def recreate(failed_greenlet):


### PR DESCRIPTION
If a consumer finishes without ack'ing, it's put back in the pool but won't be given another message, locking the consumer and message.

The dispatcher should assume that if a consumer finishes without an exception the message was processed and should be ack'd before putting the consumer back in the pool.
