### PR TITLE
Use standard logging practices instead of logging on "amqp-dispatcher"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,13 +226,3 @@ And then a session created during the consume method.
             session = self.sessionmaker()
             # Do something with the session
             session.close()
-
-Logging
--------
-
-Logging is performed on the logger ``amqp-dispatcher``. The RabbitMQ connection
-provided by Haigha will log on ``amqp-dispatcher.haigha``.
-
-You can also configure the logger by using the ``LOGGING_FILE_CONFIG``
-environment variable to specify a file config path. This will be used by
-``logging.config.fileConfig`` before creating the initial logger.

--- a/amqpdispatcher/dispatcher.py
+++ b/amqpdispatcher/dispatcher.py
@@ -1,28 +1,24 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 import asyncio
-import logging
+from logging.config import fileConfig
 import os
 
 from amqpdispatcher.dispatcher_common import get_args_from_cli, initialize_dispatcher
+from amqpdispatcher.logging import getLogger
 from amqpdispatcher.validate import validate
+
+logger = getLogger(__name__)
 
 
 def main() -> None:
     if os.getenv("LOGGING_FILE_CONFIG"):
-        logging.config.fileConfig(os.getenv("LOGGING_FILE_CONFIG"))  # type: ignore
-    else:
-        logformat = (
-            "[%(asctime)s] %(name)s [pid:%(process)d] - %(levelname)s - %(message)s"
-        )
-        datefmt = "%Y-%m-%d %H:%M:%S"
-        logging.basicConfig(level=logging.DEBUG, format=logformat, datefmt=datefmt)
+        fileConfig(os.getenv("LOGGING_FILE_CONFIG"))
 
     args = get_args_from_cli()
     if args.validate:
         return validate(args.config)
 
-    logger = logging.getLogger("amqp-dispatcher")
     logger.info("Connection: aio_pika")
 
     loop = asyncio.get_event_loop()

--- a/amqpdispatcher/dispatcher_common.py
+++ b/amqpdispatcher/dispatcher_common.py
@@ -7,23 +7,24 @@ import types
 from asyncio import AbstractEventLoop
 from typing import Dict, Optional, Type, Any, Awaitable, Callable, List
 from typing_extensions import Protocol
-from sys import exit
+from sys import exit, stdout
 
 import aio_pika
 import importlib
-import logging
 import random
 import string
 import yaml
 
-import six
 from aio_pika import Queue, Channel, IncomingMessage
 
 from amqpdispatcher.amqp_proxy import AMQPProxy
 from amqpdispatcher.environment import Environment
+from amqpdispatcher.logging import getLogger
 from amqpdispatcher.message import Message
 from amqpdispatcher.truly_robust_connection import TrulyRobustConnection
 from amqpdispatcher.wait_group import WaitGroup
+
+logger = getLogger(__name__)
 
 
 class DispatcherConsumer(Protocol):
@@ -59,14 +60,12 @@ def channel_closed_cb(
     ch: Channel, reply_code: Optional[str] = None, reply_text: Optional[str] = None
 ) -> None:
     info = "[{0}] {1}".format(reply_code, reply_text)
-    logger = logging.getLogger("amqp-dispatcher")
     logger.info("AMQP channel closed; close-info: {0}".format(info))
     return
 
 
 def create_connection_closed_cb() -> Callable[[Any, Any], None]:
     def connection_closed_cb(*args: Any, **kwargs: Any) -> None:
-        logger = logging.getLogger("amqp-dispatcher")
         logger.info("AMQP broker connection closed; close-info")
 
     return connection_closed_cb
@@ -74,7 +73,6 @@ def create_connection_closed_cb() -> Callable[[Any, Any], None]:
 
 def create_reconnection_callback() -> Callable[[Any, Any], None]:
     def reconnect_callback(*args: Any, **kwargs: Any) -> None:
-        logger = logging.getLogger("amqp-dispatcher")
         logger.info("AMQP broker reconnected!; close-info")
 
     return reconnect_callback
@@ -82,7 +80,6 @@ def create_reconnection_callback() -> Callable[[Any, Any], None]:
 
 async def create_queue(channel: Channel, queue: Dict[str, Any]) -> Queue:
     """creates a queue synchronously"""
-    logger = logging.getLogger("amqp-dispatcher")
     name = queue["queue"]
     logger.info("Create queue {0}".format(name))
     durable = bool(queue.get("durable", True))
@@ -128,7 +125,6 @@ async def create_queue(channel: Channel, queue: Dict[str, Any]) -> Queue:
 
 async def bind_queue(created_queue: Queue, queue_spec: Dict[str, Any]) -> None:
     """binds a queue to the bindings identified in the doc"""
-    logger = logging.getLogger("amqp-dispatcher")
     logger.debug("Binding queue {0}".format(queue_spec))
     bindings = queue_spec.get("bindings", [])
 
@@ -160,7 +156,6 @@ def load_module(module_name: str) -> types.ModuleType:
 
 
 def load_consumer(consumer_str: str) -> Type[DispatcherConsumer]:
-    logger = logging.getLogger("amqp-dispatcher")
     logger.debug("Loading consumer {0}".format(consumer_str))
     return load_module_object(consumer_str)
 
@@ -177,7 +172,6 @@ async def consumption_coroutine(
     wrapped_message: Message,
     wait_group: WaitGroup,
 ) -> None:
-    logger = logging.getLogger("amqp-dispatcher")
 
     # Block until we get a free consumer instance
     consumer_instance = await consumer_pool.get()
@@ -218,7 +212,6 @@ async def create_consumption_task(
     :param connection_name:
     :return:
     """
-    logger = logging.getLogger("amqp-dispatcher")
 
     queue_name = consumer["queue"]
     prefetch_count = consumer.get("prefetch_count", 1)
@@ -311,7 +304,6 @@ def create_begin_consumption_task(
 
 
 async def initialize_dispatcher(loop: AbstractEventLoop) -> None:
-    logger = logging.getLogger("amqp-dispatcher")
     logger.info("initialized amqp-dispatcher")
     args = get_args_from_cli()
     config = yaml.safe_load(open(args.config).read())

--- a/amqpdispatcher/logging.py
+++ b/amqpdispatcher/logging.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+
+def getLogger(name, level=logging.DEBUG, fmt=None, datefmt=None):
+    fmt = fmt or "[%(asctime)s] %(name)s [pid:%(process)d] - %(levelname)s - %(message)s"
+    datefmt = datefmt or "%Y-%m-%d %H:%M:%S"
+
+    std_out_handler = logging.StreamHandler(sys.stdout)
+    std_out_handler.setLevel(level)
+    std_out_handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+
+    logger = logging.getLogger(name)
+    logger.addHandler(std_out_handler)
+    return logger

--- a/amqpdispatcher/truly_robust_connection.py
+++ b/amqpdispatcher/truly_robust_connection.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from asyncio import AbstractEventLoop, Future
 from typing import Callable, Set, Optional, Dict, Any, Type, Awaitable
 
@@ -9,9 +8,10 @@ from aio_pika.exceptions import CONNECTION_EXCEPTIONS
 from aio_pika.tools import CallbackCollection
 from aio_pika.types import TimeoutType
 
+from amqpdispatcher.logging import getLogger
 from amqpdispatcher.wait_group import WaitGroup
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class TrulyRobustConnection(Connection):

--- a/examples/example_consumer.py
+++ b/examples/example_consumer.py
@@ -1,10 +1,10 @@
 import asyncio
-import logging
 import traceback
 
 from amqpdispatcher.amqp_proxy import AMQPProxy
+from amqpdispatcher.logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class Consumer(object):
@@ -24,6 +24,6 @@ class Consumer(object):
 
     async def shutdown(self, exception=None):
         if exception is not None:
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
         else:
-            logging.debug("Shut down primary worker cleanly")
+            logger.debug("Shut down primary worker cleanly")

--- a/examples/example_secondary_consumer.py
+++ b/examples/example_secondary_consumer.py
@@ -1,9 +1,9 @@
 import asyncio
-import logging
 import traceback
 
+from amqpdispatcher.logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class SecondaryConsumer(object):
@@ -22,6 +22,6 @@ class SecondaryConsumer(object):
 
     async def shutdown(self, exception=None):
         if exception is not None:
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
         else:
-            logging.debug("Shut down secondary worker cleanly")
+            logger.debug("Shut down secondary worker cleanly")

--- a/examples/example_startup.py
+++ b/examples/example_startup.py
@@ -1,6 +1,7 @@
-import logging
+from amqpdispatcher.logging import getLogger
+
+logger = getLogger(__name__)
 
 
 def startup():
-    logger = logging.getLogger("amqp-dispatcher")
     logger.info("we started up")

--- a/tests/consumers/base_test_consumer.py
+++ b/tests/consumers/base_test_consumer.py
@@ -1,11 +1,11 @@
-import logging
 import traceback
 from typing import Optional
 
 from amqpdispatcher.amqp_proxy import AMQPProxy
+from amqpdispatcher.logging import getLogger
 from amqpdispatcher.message import Message
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class BaseTestConsumer(object):
@@ -21,9 +21,9 @@ class BaseTestConsumer(object):
 
     async def shutdown(self, exception: Optional[Exception] = None) -> None:
         if exception is not None:
-            logging.error(traceback.format_exc())
+            logger.error(traceback.format_exc())
         else:
-            logging.info("shutting down {0}".format(self.class_name))
+            logger.info("shutting down {0}".format(self.class_name))
 
     def __del__(self) -> None:
         logger.info("{0} destroyed".format(self.class_name))

--- a/tests/consumers/forever_consumer.py
+++ b/tests/consumers/forever_consumer.py
@@ -1,11 +1,8 @@
 import asyncio
-import logging
 
 from amqpdispatcher.amqp_proxy import AMQPProxy
 from amqpdispatcher.message import Message
 from tests.consumers.base_test_consumer import BaseTestConsumer
-
-logger = logging.getLogger(__name__)
 
 
 class ForeverConsumer(BaseTestConsumer):

--- a/tests/consumers/immediate_consumer.py
+++ b/tests/consumers/immediate_consumer.py
@@ -1,9 +1,5 @@
-import logging
-
 from amqpdispatcher.amqp_proxy import AMQPProxy
 from tests.consumers.base_test_consumer import BaseTestConsumer
-
-logger = logging.getLogger(__name__)
 
 
 class ImmediateConsumer(BaseTestConsumer):

--- a/tests/consumers/publish_consumer.py
+++ b/tests/consumers/publish_consumer.py
@@ -1,10 +1,5 @@
-import asyncio
-import logging
-
 from amqpdispatcher.amqp_proxy import AMQPProxy
 from tests.consumers.base_test_consumer import BaseTestConsumer
-
-logger = logging.getLogger(__name__)
 
 
 class PublishConsumer(BaseTestConsumer):

--- a/tests/consumers/timed_consumer.py
+++ b/tests/consumers/timed_consumer.py
@@ -1,10 +1,10 @@
 import asyncio
-import logging
 
 from amqpdispatcher.amqp_proxy import AMQPProxy
+from amqpdispatcher.logging import getLogger
 from tests.consumers.base_test_consumer import BaseTestConsumer
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class TimedConsumer(BaseTestConsumer):


### PR DESCRIPTION
Just spent all day tracking this down. All import errors fail to log when importing from amqp-dispatcher, unless the importing code thinks to add a handlers to `logging.getLogger("amqp-dispatcher")`. This is unintuitive and confusing, and I'd rather err on the side of logging too many things than too few.